### PR TITLE
Use binary mode when writing cache and temp files

### DIFF
--- a/lib/yumrepo.rb
+++ b/lib/yumrepo.rb
@@ -143,6 +143,7 @@ module YumRepo
       FileUtils.mkdir_p File.join(@settings.cache_path, cache_dir_name) if @settings.cache_enabled
       f = File.open(cache_file_name, "w+") if @settings.cache_enabled
       f ||= Tempfile.new(filename)
+      f.binmode
       @settings.log.debug "Caching #{filename} for #{data_url} at #{f.path}"
       f.puts open(data_url).read
       f.pos = 0


### PR DESCRIPTION
Ruby 1.9.2 is really sensitive to string encoding.  When dealing with strings and files if the value isn't within the range of the encoding (UTF8 by default) it throws an exception.  This was occurring when downloading the gziped centos repo XML.  By switching the temp or cache files to binary mode it avoids this issue.
