### PR TITLE
Fixed tempfile leak for long running processes, exposed repo metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ group :development do
   gem 'nokogiri', '~> 1.5.0'
   gem 'bundler', '~> 1.0.0'
   gem 'jeweler', '~> 1.5.2'
+  gem 'i18n'
+  gem 'active_support'
   gem 'guard'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,15 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    active_support (3.0.0)
+      activesupport (= 3.0.0)
+    activesupport (3.0.0)
     diff-lcs (1.1.3)
     fakeweb (1.3.0)
     git (1.2.5)
     guard (0.8.4)
       thor (~> 0.14.6)
+    i18n (0.6.0)
     jeweler (1.5.2)
       bundler (~> 1.0.0)
       git (>= 1.2.5)
@@ -32,9 +36,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_support
   bundler (~> 1.0.0)
   fakeweb
   guard
+  i18n
   jeweler (~> 1.5.2)
   nokogiri (~> 1.5.0)
   rspec (~> 2.6)

--- a/lib/yumrepo.rb
+++ b/lib/yumrepo.rb
@@ -9,6 +9,7 @@ require 'digest/md5'
 require 'fileutils'
 require 'logger'
 require 'tempfile'
+require 'active_support/core_ext'
 
 module YumRepo
 
@@ -121,6 +122,24 @@ module YumRepo
         @primary_xml = _open_file("primary.xml.gz", @url_digest, pl.first)
       end
       @primary_xml
+    end
+
+    def meta
+      def to_sym(h)
+        h.inject({}) { |result, (key, value)|
+          new_key = case key
+                    when String then key.to_sym
+                    else key
+                    end
+          new_value = case value
+                      when Hash then to_sym(value)
+                      else value
+                      end
+          result[new_key] = new_value
+          result
+        }
+      end
+      Hash[Hash.from_xml(@repomd.to_s)["repomd"]["data"].map {|h| [h["type"].to_sym, to_sym(h)] }]
     end
 
     def other

--- a/spec/yumrepo_spec.rb
+++ b/spec/yumrepo_spec.rb
@@ -10,6 +10,15 @@ describe YumRepo do
   YumRepo::Settings.instance.log_level = :error
   YumRepo::Settings.instance.cache_enabled = false
 
+
+  describe "meta" do
+    it "make sure we get a hash whose keys are symbols" do
+      repo = YumRepo::Repomd.new "http://centos.mirror.freedomvoice.com/6.0/os/SRPMS"
+      repo.meta[:primary].should_not == nil
+      repo.meta[:primary][:checksum].should == "7ae73bdcb5961b03a0ca22419bd8da19ddc8c241"
+    end
+  end
+
   describe "package list" do
     it "for test_data should have 5 entries" do
       pl = YumRepo::PackageList.new "http://centos.mirror.freedomvoice.com/6.0/os/SRPMS"


### PR DESCRIPTION
For long running processes we were leaking tempfiles.  I was previously relying upon the garbage collector to cleanup the temp files when caching was set to false.  This was resulting in a leak of files that for long running processes would eventually fill up the disk.  I now explicitly clean up the files when I'm done with them.

I needed access to the metadata for repos such as the timestamp and SHA hash.  We previously didn't make this information available.  I've exposed it via Repomd#meta and added corresponding unit tests.
